### PR TITLE
Update minimum version of Guard to 2.9

### DIFF
--- a/guard-notifier-blink1.gemspec
+++ b/guard-notifier-blink1.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "guard", "~> 2.1"
+  spec.add_runtime_dependency "guard", "~> 2.9"
   spec.add_runtime_dependency "colorable", "~> 0.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
The `Guard::Notifier::SUPPORTED` constant was not available until Guard 2.9.0.

With Guard versions less than 2.9, I would get the following error:

```
08:30:21 - ERROR - Invalid Guardfile, original error is:
> [#] uninitialized constant Guard::Notifier::SUPPORTED
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-notifier-blink1-0.2.2/lib/guard/notifier/blink1.rb:81:in `<module:Notifier>': uninitialized constant Guard::Notifier::SUPPORTED (NameError)
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-notifier-blink1-0.2.2/lib/guard/notifier/blink1.rb:3:in `<module:Guard>'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-notifier-blink1-0.2.2/lib/guard/notifier/blink1.rb:2:in `<top (required)>'
        from /home/charles/dev/sales/Guardfile:4:in `require'
        from /home/charles/dev/sales/Guardfile:4:in `_instance_eval_guardfile'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/lib/guard/guardfile/evaluator.rb:117:in `instance_eval'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/lib/guard/guardfile/evaluator.rb:117:in `_instance_eval_guardfile'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/lib/guard/guardfile/evaluator.rb:53:in `evaluate_guardfile'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/lib/guard/setuper.rb:143:in `evaluate_guardfile'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/lib/guard/setuper.rb:339:in `_load_guardfile'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/lib/guard/setuper.rb:60:in `setup'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/lib/guard/commander.rb:23:in `start'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/lib/guard/cli.rb:112:in `start'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/lib/guard/aruba_adapter.rb:32:in `execute'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/lib/guard/aruba_adapter.rb:19:in `execute!'
        from /home/charles/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/guard-2.7.1/bin/guard:11:in `<top (required)>'
        from /home/charles/.rbenv/versions/2.1.4/bin/guard:23:in `load'
        from /home/charles/.rbenv/versions/2.1.4/bin/guard:23:in `<main>'
```
